### PR TITLE
refactor: Stop camera and lidar threads on DataTransferer stop

### DIFF
--- a/RPIs/DataManager/DataTransferer/DataTransferer.py
+++ b/RPIs/DataManager/DataTransferer/DataTransferer.py
@@ -16,15 +16,24 @@ class DataTransferer:
         self.interpolated_lidar_data = interpolated_lidar_data
 
     def start(self):
-        camera_thread = threading.Thread(target=self.process_cam_frames)
-        camera_thread.start()
+        self.camera_thread = threading.Thread(target=self.process_cam_frames)
+        self.camera_thread.daemon = True
+        self.camera_thread.start()
         
         print("Camera thread started")
 
-        lidar_thread = threading.Thread(target=self.process_lidar_data)
-        lidar_thread.start()
+        self.lidar_thread = threading.Thread(target=self.process_lidar_data)
+        self.lidar_thread.daemon = True
+        self.lidar_thread.start()
         
         print("Lidar thread started")
+
+        #stop those
+
+
+    def stop(self):
+        self.camera_thread.join()
+        self.lidar_thread.join()
 
     def process_cam_frames(self):
         print("Processing camera frames", self.camera)

--- a/RPIs/DataManager/Mainloops/TrainingLoop.py
+++ b/RPIs/DataManager/Mainloops/TrainingLoop.py
@@ -16,41 +16,46 @@ def main_loop_training(self):
     cross_pressed = False
 
     start_time = time.time()
+
+    try:
     
-    while self.running:
-        if ps_controller.cross == 1 and not cross_pressed:
-            cross_pressed = True
-            recording_status = not recording_status
-            self.logger.info(f"Recording status: {recording_status}")
-        elif ps_controller.cross == 0:
-            cross_pressed = False
-            # self.logger.info("Cross button released")
-        
-        if len(self.interpolated_lidar_data) > 0:
-            lidar_data = deepcopy(self.interpolated_lidar_data[-1])
-            x, y, rx, ry = ps_controller.get_analog_stick_values()
-
-            lidar_data_str = f"LIDAR_DATA#{lidar_data}"
-            analog_sticks_str = f"ANALOG_STICKS#{x}#{y}#{rx}#{ry}"
-
-            # print(f"Analogdatastr: {analog_sticks_str}")
-             
-            self.client.send_message(lidar_data_str)
-            self.client.send_message(analog_sticks_str)
+        while self.running:
+            if ps_controller.cross == 1 and not cross_pressed:
+                cross_pressed = True
+                recording_status = not recording_status
+                self.logger.info(f"Recording status: {recording_status}")
+            elif ps_controller.cross == 0:
+                cross_pressed = False
+                # self.logger.info("Cross button released")
             
-            if recording_status:
-                with open(f"RPIs/DataManager/Data/lidar_data_{file_uuid}_{date}.txt", "a") as file:
-                    file.write(f"{lidar_data}\n")
-                    
-                with open(f"RPIs/DataManager/Data/x_values_{file_uuid}_{date}.txt", "a") as file:
-                    file.write(f"{x}\n")
-        
-        end_time = time.time()
-        print(f"Loop iteration time: {end_time - start_time} seconds")
+            if len(self.interpolated_lidar_data) > 0:
+                lidar_data = deepcopy(self.interpolated_lidar_data[-1])
+                x, y, rx, ry = ps_controller.get_analog_stick_values()
 
-        sleep_time = 0.1 - (end_time - start_time)
+                lidar_data_str = f"LIDAR_DATA#{lidar_data}"
+                analog_sticks_str = f"ANALOG_STICKS#{x}#{y}#{rx}#{ry}"
 
-        if sleep_time > 0:
-            time.sleep(sleep_time)
+                # print(f"Analogdatastr: {analog_sticks_str}")
+                
+                self.client.send_message(lidar_data_str)
+                self.client.send_message(analog_sticks_str)
+                
+                if recording_status:
+                    with open(f"RPIs/DataManager/Data/lidar_data_{file_uuid}_{date}.txt", "a") as file:
+                        file.write(f"{lidar_data}\n")
+                        
+                    with open(f"RPIs/DataManager/Data/x_values_{file_uuid}_{date}.txt", "a") as file:
+                        file.write(f"{x}\n")
+            
+            end_time = time.time()
+            print(f"Loop iteration time: {end_time - start_time} seconds")
 
-        start_time = time.time()
+            sleep_time = 0.1 - (end_time - start_time)
+
+            if sleep_time > 0:
+                time.sleep(sleep_time)
+
+            start_time = time.time()
+
+    except KeyboardInterrupt:
+        pass

--- a/RPIs/WebServer/WebServer.py
+++ b/RPIs/WebServer/WebServer.py
@@ -37,7 +37,7 @@ class WebServer:
         try:
             self.socketio.run(self.app, host=self.host, port=self.port, debug=False, use_reloader=False, allow_unsafe_werkzeug=True, log_output=False)
         except Exception as e:
-            # print(f"An error occurred: {e}")
+            print(f"An error occurred: {e}")
             pass
         finally:
             print("Web server stopped")


### PR DESCRIPTION
This commit modifies the `DataTransferer` class to stop the camera and lidar threads when the `stop` method is called. The camera and lidar threads are now set as daemon threads, ensuring they are terminated when the main thread exits. This change improves the cleanup and termination process of the `DataTransferer` class.